### PR TITLE
fix: align package module entry with published ESM file

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     }
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"


### PR DESCRIPTION
## Summary
- update the package `module` field to point at `./dist/index.js`, matching the ESM file produced in the published package and the existing `exports["."].import` target

## Reproduction
The published `rsbuild-plugin-unplugin-vue@0.2.0` package advertises `module: "./dist/index.mjs"`, but the npm tarball contains `dist/index.js`, `dist/index.cjs`, and `dist/index.d.ts`; it does not contain `dist/index.mjs`.

```sh
npm view rsbuild-plugin-unplugin-vue@0.2.0 name version main module exports --json
npm pack rsbuild-plugin-unplugin-vue@0.2.0 --dry-run --json --ignore-scripts
```

## Validation
- package metadata assertion: `module` and `exports["."].import` both resolve to `./dist/index.js`
- `git diff --check`
