### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "rsbuild-plugin-unplugin-vue",
   "version": "0.2.0",
+  "bugs": {
+    "url": "https://github.com/rstackjs/rsbuild-plugin-unplugin-vue/issues"
+  },
   "repository": "https://github.com/rstackjs/rsbuild-plugin-unplugin-vue",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Adds missing `bugs` metadata to `package.json`.

Fixes npm tooling unable to resolve package metadata.